### PR TITLE
Setting year and month as integer variables

### DIFF
--- a/R/annual_rainfall_summaries.R
+++ b/R/annual_rainfall_summaries.R
@@ -24,6 +24,7 @@ annual_rainfall_summaries <- function(country,
                                       ) {
   # cheaper to not save this and to just call it?
   daily <- epicsadata::get_daily_data(country = country, station_id = station_id)
+  daily$year <- as.integer(daily$year)
   definitions <- definitions(country = country, station_id = station_id, summaries = summaries)
   summary_data <- expand.grid(year = unique(daily$year), station = unique(daily$station))
   if ("annual_rain" %in% summaries){
@@ -72,6 +73,6 @@ annual_rainfall_summaries <- function(country,
   # anything defined in the json to go in here
   # and to be returned in that format (e.g. dataframe, list of lists, etc)
   list_return[[1]] <- c(definitions)
-  list_return[[2]] <- summary_data %>% mutate(year = as.integer(year))
+  list_return[[2]] <- summary_data
   return(list_return) # return a list with in it the metadata and the data itself
 }

--- a/R/annual_rainfall_summaries.R
+++ b/R/annual_rainfall_summaries.R
@@ -72,6 +72,6 @@ annual_rainfall_summaries <- function(country,
   # anything defined in the json to go in here
   # and to be returned in that format (e.g. dataframe, list of lists, etc)
   list_return[[1]] <- c(definitions)
-  list_return[[2]] <- summary_data
+  list_return[[2]] <- summary_data %>% mutate(year = as.integer(year))
   return(list_return) # return a list with in it the metadata and the data itself
 }

--- a/R/monthly_temperature_summaries.R
+++ b/R/monthly_temperature_summaries.R
@@ -1,4 +1,4 @@
-#' monthly Temperature Summaries
+#' Monthly Temperature Summaries
 #'
 #' @param country `character(1)` The country code of the data.
 #' @param station_id `character` The id's of the stations to analyse. Either a

--- a/R/total_temperature_summaries.R
+++ b/R/total_temperature_summaries.R
@@ -19,6 +19,11 @@ total_temperature_summaries <- function(country,
                                         to = c("annual", "monthly")) {
   to <- match.arg(to)
   daily <- epicsadata::get_daily_data(country = country, station_id = station_id)
+  daily$year <- as.integer(daily$year)
+  if ("month" %in% names(daily)){
+    daily$month <- forcats::as_factor(daily$month) # what about reordering this further if we didn't have it in order at the start?
+    daily$month <- as.integer(daily$month) 
+  } 
   definitions <- epicsawrap::definitions(country = country, station_id = station_id, summaries = summaries)
   
   # even though we can have tmax and tmin defined together, it's being done this way 

--- a/man/monthly_temperature_summaries.Rd
+++ b/man/monthly_temperature_summaries.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/monthly_temperature_summaries.R
 \name{monthly_temperature_summaries}
 \alias{monthly_temperature_summaries}
-\title{monthly Temperature Summaries}
+\title{Monthly Temperature Summaries}
 \usage{
 monthly_temperature_summaries(
   country,
@@ -22,7 +22,7 @@ single value or a vector.}
 A data frame with monthly summaries.
 }
 \description{
-monthly Temperature Summaries
+Monthly Temperature Summaries
 }
 \examples{
 # monthly_temperature_summaries(country = "zm", station_id = "16") # made a fake "16" json definitions data


### PR DESCRIPTION
@lloyddewit this PR sets the "year" and "month" variables as integers in the

`annual_rainfall_summaries`
`annual_temperature_summaries`
`monthly_temperature_summaries`

functions