### PR TITLE
Adding `seasonal_length` and `seasonal_rain` summaries into `annual_rainfall_summaries`

### DIFF
--- a/R/season_start_probabilities.R
+++ b/R/season_start_probabilities.R
@@ -21,10 +21,10 @@ season_start_probabilities <- function(country,
   definitions <- epicsawrap::definitions(country = country, station_id = station_id, summaries = "season_start_probabilities")
   season_data <- annual_rainfall_summaries(country = country, station_id = station_id, summaries = c("start_rains"))
   summary_probabilities <- rpicsa::probability_season_start(data = season_data[[2]],
-                              station = "station",
-                              start_rains = "start_rain",
-                              doy_format = "doy_366", # we calculate this in the start_rain summaries?
-                              specified_day = as.numeric(definitions$season_start_probabilities$specified_day))
+                                                            station = "station",
+                                                            start_rains = "start_rain",
+                                                            doy_format = "doy_366", # we calculate this in the start_rain summaries?
+                                                            specified_day = as.numeric(definitions$season_start_probabilities$specified_day))
   list_return <- NULL
   list_return[[1]] <- c(season_data[[1]], definitions)
   list_return[[2]] <- summary_probabilities

--- a/man/annual_rainfall_summaries.Rd
+++ b/man/annual_rainfall_summaries.Rd
@@ -7,7 +7,8 @@
 annual_rainfall_summaries(
   country,
   station_id,
-  summaries = c("annual_rain", "start_rains", "end_rains")
+  summaries = c("annual_rain", "start_rains", "end_rains", "end_season", "seasonal_rain",
+    "seasonal_length")
 )
 }
 \arguments{
@@ -28,4 +29,6 @@ One row per year/station and one column per summary.
 }
 \examples{
 annual_rainfall_summaries(country = "zm", station_id = "01122", summaries = "annual_rain")
+annual_rainfall_summaries(country = "zm", station_id = "16", 
+                          summaries = c("start_rains", "end_rains", "annual_rain", "seasonal_length")) #, "end_season"))
 }


### PR DESCRIPTION
@lloyddewit the `annual_rainfall_summaries` function should be "complete" now (I put in quotes because there will inevitably be changes to the function, but nothing you need to worry about).

Let me know if there are any issues/queries.

For `seasonal_length` and `seasonal_rain` summaries, `start_rains` needs to be a summary, as well as at least one of `end_rains` and `end_season`. Is this okay?