### PR TITLE
Adding functionality to station_metadata

### DIFF
--- a/R/station_metadata.R
+++ b/R/station_metadata.R
@@ -4,10 +4,10 @@
 #' @param country A character vector specifying the country or countries from which to get the metadata. Options include "zm" (Zambia) and "mz" (Mozambique).
 #' @param station_id A character vector specifying the station IDs to filter by. If provided, only metadata for the specified station IDs will be returned.
 #' @param include_definitions A logical value indicating whether to include definitions data. If TRUE, additional information about station definitions will be included in the output.
-#' @param format A character vector specifying the format of the output. Options are "wide" (default), "long", or "nested".
+#' @param format A character vector specifying the format of the output. Options are "wide" (default), "long", "nested", or "list".
 #' @return If `include_definitions` is FALSE, the function returns a data frame with metadata for the specified stations. If `include_definitions` is TRUE, it returns a data frame with both metadata and station definitions.
 #' 
 #' @export
-station_metadata <- function(country = NULL, station_id = NULL, include_definitions = FALSE, format = c("wide", "long", "nested")) {
+station_metadata <- function(country = NULL, station_id = NULL, include_definitions = FALSE, format = c("wide", "long", "nested", "list")) {
   epicsadata::station_metadata(country = country, station_id = station_id, include_definitions = include_definitions, format = format)
 }

--- a/man/station_metadata.Rd
+++ b/man/station_metadata.Rd
@@ -8,7 +8,7 @@ station_metadata(
   country = NULL,
   station_id = NULL,
   include_definitions = FALSE,
-  format = c("wide", "long", "nested")
+  format = c("wide", "long", "nested", "list")
 )
 }
 \arguments{
@@ -18,7 +18,7 @@ station_metadata(
 
 \item{include_definitions}{A logical value indicating whether to include definitions data. If TRUE, additional information about station definitions will be included in the output.}
 
-\item{format}{A character vector specifying the format of the output. Options are "wide" (default), "long", or "nested".}
+\item{format}{A character vector specifying the format of the output. Options are "wide" (default), "long", "nested", or "list".}
 }
 \value{
 If \code{include_definitions} is FALSE, the function returns a data frame with metadata for the specified stations. If \code{include_definitions} is TRUE, it returns a data frame with both metadata and station definitions.


### PR DESCRIPTION
From issue #76 request:

> station - can definitions come back in the same format as metadata?

This PR adds functionality to ensure definitions can come back in the same format at the metadata (list format).

This can be achieved by running `format = "list"` in the function, e.g.,

```
station_metadata("zm", station_id = c(1, 28), include_definitions = TRUE, format = "list")
```